### PR TITLE
OBA-1402: privy integration CMD on dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,4 @@ RUN pnpm run build
 
 EXPOSE 4173
 
-CMD [ "pnpm", "preview" ]
+CMD [ "pnpm", "preview", "--host" ]


### PR DESCRIPTION
**WHAT**
- privy integration CMD on dockerfile

**WHY**
- needs the "host" flag to serve it outside the container