### PR TITLE
ci(release): use shared reusable release workflow with GitHub App auth

### DIFF
--- a/.github/workflows/automatic-releases.yaml
+++ b/.github/workflows/automatic-releases.yaml
@@ -12,6 +12,8 @@ jobs:
       default_bump: patch
       runner: ubuntu-latest
     secrets:
+      # Transitional fallback: delete envPat once releases are confirmed
+      # running via the GitHub App, then remove the CI_PAT_TOKEN secret.
       envPat: ${{ secrets.CI_PAT_TOKEN }}
       releaseAppId: ${{ secrets.RELEASE_BOT_APP_ID }}
       releaseAppPrivateKey: ${{ secrets.RELEASE_BOT_APP_PRIVATE_KEY }}

--- a/.github/workflows/automatic-releases.yaml
+++ b/.github/workflows/automatic-releases.yaml
@@ -7,29 +7,11 @@ on:
 
 jobs:
   github-release:
-    name: Bump version
-    runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.message, 'Initial commit')"
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.CI_PAT_TOKEN }}
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: '0'
-
-      - name: Bump version and push tag
-        uses: anothrNick/github-tag-action@v1
-        id: tag
-        env:
-          GITHUB_TOKEN: ${{ secrets.CI_PAT_TOKEN }}
-          WITH_V: true
-          DEFAULT_BUMP: patch
-
-      - name: Create Release
-        uses: softprops/action-gh-release@v1
-        with:
-          tag_name: ${{ steps.tag.outputs.new_tag }}
-          draft: false
-          prerelease: false
-          generate_release_notes: true
-          token: ${{ secrets.CI_PAT_TOKEN }}
+    uses: OneBalance-io/infra-iac/.github/workflows/reuse-auto-releases.yaml@main
+    with:
+      default_bump: patch
+      runner: ubuntu-latest
+    secrets:
+      envPat: ${{ secrets.CI_PAT_TOKEN }}
+      releaseAppId: ${{ secrets.RELEASE_BOT_APP_ID }}
+      releaseAppPrivateKey: ${{ secrets.RELEASE_BOT_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary
Forwards the new optional `releaseAppId` / `releaseAppPrivateKey` org secrets to the shared `reuse-auto-releases.yaml` workflow so releases authenticate via the dedicated **GitHub App installation** (`OneBalance Release Bot`) instead of the shared `OBDevOpsBot` PAT. `envPat` is retained as a fallback during migration.

## Why
Moves release API traffic off the shared bot PAT (flat 5,000 req/hr, the source of the rate-limit 403s) onto a dedicated, higher, scalable budget, while preserving downstream `on: push: tags` triggering. See OneBalance-io/infra-iac#341.

## Merge order (important)
1. Merge OneBalance-io/infra-iac#341 first — it declares the new optional secrets on the reusable workflow. Forwarding them before that errors at runtime.
2. Create the `OneBalance Release Bot` App + org secrets `RELEASE_BOT_APP_ID` / `RELEASE_BOT_APP_PRIVATE_KEY`.
3. Then merge this PR.

Until the org App secrets exist, the reusable workflow falls back to the PAT, so merging after step 1 is safe even before the App is live.